### PR TITLE
make pvp use channels

### DIFF
--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -4030,15 +4030,33 @@ ATCE atcommand_character_storage_list(Session *s, dumb_ptr<map_session_data> sd,
 }
 
 static
+ATCE atcommand_pvp(Session *s, dumb_ptr<map_session_data> sd,
+        ZString)
+{
+    if (sd->pvp_timer || sd->state.killable || sd->state.killer)
+        return ATCE::OKAY;
+
+    sd->state.pvpon = !sd->state.pvpon;
+    pc_setpvptimer(sd, battle_config.player_pvp_time);
+
+    if (sd->state.pvpon)
+        clif_displaymessage(s, "##3PvP : ##BOn"_s);
+    else
+        clif_displaymessage(s, "##3PvP : ##BOff"_s);
+
+    return ATCE::OKAY;
+}
+
+static
 ATCE atcommand_killer(Session *s, dumb_ptr<map_session_data> sd,
         ZString)
 {
-    sd->special_state.killer = !sd->special_state.killer;
+    sd->state.killer = !sd->state.killer;
 
-    if (sd->special_state.killer)
-        clif_displaymessage(s, "You be a killa..."_s);
+    if (sd->state.killer)
+        clif_displaymessage(s, "##3Killer : ##BOn"_s);
     else
-        clif_displaymessage(s, "You gonna be own3d..."_s);
+        clif_displaymessage(s, "##3Killer : ##BOff"_s);
 
     return ATCE::OKAY;
 }
@@ -4056,9 +4074,9 @@ ATCE atcommand_charkiller(Session *s, dumb_ptr<map_session_data>,
     if (pl_sd == nullptr)
         return ATCE::EXIST;
 
-    pl_sd->special_state.killer = !pl_sd->special_state.killer;
+    pl_sd->state.killer = !pl_sd->state.killer;
 
-    if (pl_sd->special_state.killer)
+    if (pl_sd->state.killer)
     {
         clif_displaymessage(s, "The player is now a killer"_s);
         clif_displaymessage(pl_sd->sess, "You are now a killer"_s);
@@ -4076,12 +4094,12 @@ static
 ATCE atcommand_killable(Session *s, dumb_ptr<map_session_data> sd,
         ZString)
 {
-    sd->special_state.killable = !sd->special_state.killable;
+    sd->state.killable = !sd->state.killable;
 
-    if (sd->special_state.killable)
-        clif_displaymessage(s, "You gonna be own3d..."_s);
+    if (sd->state.killable)
+        clif_displaymessage(s, "##3Killable : ##BOn"_s);
     else
-        clif_displaymessage(s, "You be a killa..."_s);
+        clif_displaymessage(s, "##3Killable : ##BOff"_s);
 
     return ATCE::OKAY;
 }
@@ -4099,9 +4117,9 @@ ATCE atcommand_charkillable(Session *s, dumb_ptr<map_session_data>,
     if (pl_sd == nullptr)
         return ATCE::EXIST;
 
-    pl_sd->special_state.killable = !pl_sd->special_state.killable;
+    pl_sd->state.killable = !pl_sd->state.killable;
 
-    if (pl_sd->special_state.killable)
+    if (pl_sd->state.killable)
         clif_displaymessage(s, "The player is now killable"_s);
     else
         clif_displaymessage(s, "The player is no longer killable"_s);
@@ -5236,6 +5254,9 @@ Map<XString, AtCommandInfo> atcommand_info =
     {"addwarp"_s, {"<mapname> <x> <y>"_s,
         80, atcommand_addwarp,
         "Create a new permanent warp"_s}},
+    {"pvp"_s, {""_s,
+        0, atcommand_pvp,
+        "Toggle your pvp flag"_s}},
     {"killer"_s, {""_s,
         60, atcommand_killer,
         "Toggle whether you are a killer"_s}},

--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -4033,7 +4033,7 @@ static
 ATCE atcommand_pvp(Session *s, dumb_ptr<map_session_data> sd,
         ZString)
 {
-    if (sd->pvp_timer || sd->state.killable || sd->state.killer)
+    if (sd->pvp_timer)
         return ATCE::OKAY;
 
     sd->state.pvpon = !sd->state.pvpon;
@@ -4043,86 +4043,6 @@ ATCE atcommand_pvp(Session *s, dumb_ptr<map_session_data> sd,
         clif_displaymessage(s, "##3PvP : ##BOn"_s);
     else
         clif_displaymessage(s, "##3PvP : ##BOff"_s);
-
-    return ATCE::OKAY;
-}
-
-static
-ATCE atcommand_killer(Session *s, dumb_ptr<map_session_data> sd,
-        ZString)
-{
-    sd->state.killer = !sd->state.killer;
-
-    if (sd->state.killer)
-        clif_displaymessage(s, "##3Killer : ##BOn"_s);
-    else
-        clif_displaymessage(s, "##3Killer : ##BOff"_s);
-
-    return ATCE::OKAY;
-}
-
-static
-ATCE atcommand_charkiller(Session *s, dumb_ptr<map_session_data>,
-        ZString message)
-{
-    CharName character;
-
-    if (!asplit(message, &character))
-        return ATCE::USAGE;
-
-    dumb_ptr<map_session_data> pl_sd = map_nick2sd(character);
-    if (pl_sd == nullptr)
-        return ATCE::EXIST;
-
-    pl_sd->state.killer = !pl_sd->state.killer;
-
-    if (pl_sd->state.killer)
-    {
-        clif_displaymessage(s, "The player is now a killer"_s);
-        clif_displaymessage(pl_sd->sess, "You are now a killer"_s);
-    }
-    else
-    {
-        clif_displaymessage(s, "The player is no longer a killer"_s);
-        clif_displaymessage(pl_sd->sess, "You are no longer a killer"_s);
-    }
-
-    return ATCE::OKAY;
-}
-
-static
-ATCE atcommand_killable(Session *s, dumb_ptr<map_session_data> sd,
-        ZString)
-{
-    sd->state.killable = !sd->state.killable;
-
-    if (sd->state.killable)
-        clif_displaymessage(s, "##3Killable : ##BOn"_s);
-    else
-        clif_displaymessage(s, "##3Killable : ##BOff"_s);
-
-    return ATCE::OKAY;
-}
-
-static
-ATCE atcommand_charkillable(Session *s, dumb_ptr<map_session_data>,
-        ZString message)
-{
-    CharName character;
-
-    if (!asplit(message, &character))
-        return ATCE::USAGE;
-
-    dumb_ptr<map_session_data> pl_sd = map_nick2sd(character);
-    if (pl_sd == nullptr)
-        return ATCE::EXIST;
-
-    pl_sd->state.killable = !pl_sd->state.killable;
-
-    if (pl_sd->state.killable)
-        clif_displaymessage(s, "The player is now killable"_s);
-    else
-        clif_displaymessage(s, "The player is no longer killable"_s);
 
     return ATCE::OKAY;
 }
@@ -5257,21 +5177,9 @@ Map<XString, AtCommandInfo> atcommand_info =
     {"pvp"_s, {""_s,
         0, atcommand_pvp,
         "Toggle your pvp flag"_s}},
-    {"killer"_s, {""_s,
-        60, atcommand_killer,
-        "Toggle whether you are a killer"_s}},
-    {"charkiller"_s, {"<charname>"_s,
-        60, atcommand_charkiller,
-        "Toggle whether a player is a killer"_s}},
     {"npcmove"_s, {"<x> <y> <npc-name>"_s,
         80, atcommand_npcmove,
         "Force an NPC to move on the map"_s}},
-    {"killable"_s, {""_s,
-        60, atcommand_killable,
-        "Toggle whether you are killable"_s}},
-    {"charkillable"_s, {"<charname>"_s,
-        60, atcommand_charkillable,
-        "Toggle whether a player is killable"_s}},
     {"chareffect"_s, {"<type> <target>"_s,
         40, atcommand_chareffect,
         "Apply effect type with arg 0 to a player"_s}},

--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -4033,17 +4033,19 @@ static
 ATCE atcommand_pvp(Session *s, dumb_ptr<map_session_data> sd,
         ZString)
 {
-    if (sd->pvp_timer)
+    int chan = sd->state.pvpchannel;
+    if (sd->pvp_timer || (chan > 1))
         return ATCE::OKAY;
 
-    sd->state.pvpon = !sd->state.pvpon;
-    pc_setpvptimer(sd, battle_config.player_pvp_time);
-
-    if (sd->state.pvpon)
+    if (chan < 1) {
+        sd->state.pvpchannel = 1;
         clif_displaymessage(s, "##3PvP : ##BOn"_s);
-    else
+    } else {
+        sd->state.pvpchannel = 0;
         clif_displaymessage(s, "##3PvP : ##BOff"_s);
+    }
 
+    pc_setpvptimer(sd, battle_config.player_pvp_time);
     return ATCE::OKAY;
 }
 

--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -4050,6 +4050,25 @@ ATCE atcommand_pvp(Session *s, dumb_ptr<map_session_data> sd,
 }
 
 static
+ATCE atcommand_charpvp(Session *s, dumb_ptr<map_session_data>,
+        ZString message)
+{
+    CharName character;
+    int channel;
+
+    if (!extract(message, record<' '>(&character, &channel)))
+        return ATCE::USAGE;
+
+    dumb_ptr<map_session_data> pl_sd = map_nick2sd(character);
+    if (pl_sd == nullptr)
+        return ATCE::EXIST;
+
+    pl_sd->state.pvpchannel = channel;
+
+    return ATCE::OKAY;
+}
+
+static
 ATCE atcommand_npcmove(Session *, dumb_ptr<map_session_data>,
         ZString message)
 {
@@ -5182,6 +5201,9 @@ Map<XString, AtCommandInfo> atcommand_info =
     {"npcmove"_s, {"<x> <y> <npc-name>"_s,
         80, atcommand_npcmove,
         "Force an NPC to move on the map"_s}},
+    {"charpvp"_s, {"<charname> <channel>"_s,
+        40, atcommand_charpvp,
+        "Set the pvp channel of another player"_s}},
     {"chareffect"_s, {"<type> <target>"_s,
         40, atcommand_chareffect,
         "Apply effect type with arg 0 to a player"_s}},

--- a/src/map/magic-stmt.cpp
+++ b/src/map/magic-stmt.cpp
@@ -773,8 +773,9 @@ int op_injure(dumb_ptr<env_t> env, Slice<val_t> args)
 
     if (target->bl_type == BL::PC
         && !target->bl_m->flag.get(MapFlag::PVP)
-        && !target->is_player()->special_state.killable
-        && (caster->bl_type != BL::PC || !caster->is_player()->special_state.killer))
+        && !target->is_player()->state.killable
+        && (caster->bl_type != BL::PC || !caster->is_player()->state.killer)
+        && (!target->is_player()->state.pvpon && !caster->is_player()->state.pvpon))
         return 0;               /* Cannot damage other players outside of pvp */
 
     if (target != caster)

--- a/src/map/magic-stmt.cpp
+++ b/src/map/magic-stmt.cpp
@@ -774,7 +774,7 @@ int op_injure(dumb_ptr<env_t> env, Slice<val_t> args)
     if (target->bl_type == BL::PC
         && !target->bl_m->flag.get(MapFlag::PVP)
         && (caster->bl_type != BL::PC)
-        && (!target->is_player()->state.pvpon && !caster->is_player()->state.pvpon))
+        && ((caster->is_player()->state.pvpchannel > 1) && (target->is_player()->state.pvpchannel != caster->is_player()->state.pvpchannel)))
         return 0;               /* Cannot damage other players outside of pvp */
 
     if (target != caster)

--- a/src/map/magic-stmt.cpp
+++ b/src/map/magic-stmt.cpp
@@ -773,8 +773,7 @@ int op_injure(dumb_ptr<env_t> env, Slice<val_t> args)
 
     if (target->bl_type == BL::PC
         && !target->bl_m->flag.get(MapFlag::PVP)
-        && !target->is_player()->state.killable
-        && (caster->bl_type != BL::PC || !caster->is_player()->state.killer)
+        && (caster->bl_type != BL::PC)
         && (!target->is_player()->state.pvpon && !caster->is_player()->state.pvpon))
         return 0;               /* Cannot damage other players outside of pvp */
 

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -142,11 +142,12 @@ struct map_session_data : block_list, SessionData
         unsigned shroud_disappears_on_pickup:1;
         unsigned shroud_disappears_on_talk:1;
         unsigned seen_motd:1;
+        unsigned pvpon:1;
+        unsigned killer:1;
+        unsigned killable:1;
     } state;
     struct
     {
-        unsigned killer:1;
-        unsigned killable:1;
         unsigned unbreakable_weapon:1;
         unsigned unbreakable_armor:1;
         unsigned deaf:1;

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -143,8 +143,6 @@ struct map_session_data : block_list, SessionData
         unsigned shroud_disappears_on_talk:1;
         unsigned seen_motd:1;
         unsigned pvpon:1;
-        unsigned killer:1;
-        unsigned killable:1;
     } state;
     struct
     {

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -142,7 +142,7 @@ struct map_session_data : block_list, SessionData
         unsigned shroud_disappears_on_pickup:1;
         unsigned shroud_disappears_on_talk:1;
         unsigned seen_motd:1;
-        unsigned pvpon:1;
+        unsigned pvpchannel;
     } state;
     struct
     {

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -290,10 +290,6 @@ int pc_iskiller(dumb_ptr<map_session_data> src,
 
     if (src->bl_type != BL::PC || target->bl_type != BL::PC)
         return 0;
-    if (src->state.killer)
-        return 1;
-    if (target->state.killable)
-        return 1;
     if (src->state.pvpon && target->state.pvpon && !src->bl_m->flag.get(MapFlag::NOPVP))
         return 1;
     return 0;
@@ -403,9 +399,6 @@ int pc_setrestartvalue(dumb_ptr<map_session_data> sd, int type)
         clif_updatestatus(sd, SP::SP);
 
     sd->heal_xp = 0;            // [Fate] Set gainable xp for healing this player to 0
-    sd->state.killer = 0;
-    sd->state.killable = 0;
-
     return 0;
 }
 
@@ -926,7 +919,7 @@ int pc_calcstatus(dumb_ptr<map_session_data> sd, int first)
     int bl;
     int aspd_rate, refinedef = 0;
     int str, dstr, dex;
-    int b_pvpon = 0, b_killer = 0, b_killable = 0;
+    int b_pvpon = 0;
 
     nullpo_retz(sd);
 
@@ -956,9 +949,6 @@ int pc_calcstatus(dumb_ptr<map_session_data> sd, int first)
     b_mdef2 = sd->mdef2;
     b_base_atk = sd->base_atk;
     b_pvpon = sd->state.pvpon;
-    if (!pc_isdead(sd))
-        b_killer = sd->state.killer;
-        b_killable = sd->state.killable;
 
     sd->max_weight = max_weight_base_0 + sd->status.attrs[ATTR::STR] * 300;
 
@@ -1433,11 +1423,6 @@ int pc_calcstatus(dumb_ptr<map_session_data> sd, int first)
         clif_updatestatus(sd, SP::SP);
     if (b_pvpon != sd->state.pvpon)
         sd->state.pvpon = b_pvpon;
-    if (b_killer != sd->state.killer)
-        sd->state.killable = b_killer;
-    if (b_killable != sd->state.killable)
-        sd->state.killable = b_killable;
-
 
     return 0;
 }

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -288,16 +288,14 @@ int pc_iskiller(dumb_ptr<map_session_data> src,
 {
     nullpo_retz(src);
 
-    if (src->bl_type != BL::PC)
+    if (src->bl_type != BL::PC || target->bl_type != BL::PC)
         return 0;
-    if (src->special_state.killer)
+    if (src->state.killer)
         return 1;
-
-    if (target->bl_type != BL::PC)
-        return 0;
-    if (target->special_state.killable)
+    if (target->state.killable)
         return 1;
-
+    if (src->state.pvpon && target->state.pvpon)
+        return 1;
     return 0;
 }
 
@@ -317,6 +315,33 @@ int distance(int x0, int y0, int x1, int y1)
     dx = abs(x0 - x1);
     dy = abs(y0 - y1);
     return dx > dy ? dx : dy;
+}
+
+static
+void pc_pvp_timer(TimerData *, tick_t, BlockId id)
+{
+    dumb_ptr<map_session_data> sd = map_id2sd(id);
+
+    assert (sd != nullptr);
+    assert (sd->bl_type == BL::PC);
+}
+
+int pc_setpvptimer(dumb_ptr<map_session_data> sd, interval_t val)
+{
+    nullpo_retz(sd);
+
+    sd->pvp_timer = Timer(gettick() + val,
+            std::bind(pc_pvp_timer, ph::_1, ph::_2,
+                sd->bl_id));
+    return 0;
+}
+
+int pc_delpvptimer(dumb_ptr<map_session_data> sd)
+{
+    nullpo_retz(sd);
+
+    sd->pvp_timer.cancel();
+    return 0;
 }
 
 static
@@ -378,6 +403,8 @@ int pc_setrestartvalue(dumb_ptr<map_session_data> sd, int type)
         clif_updatestatus(sd, SP::SP);
 
     sd->heal_xp = 0;            // [Fate] Set gainable xp for healing this player to 0
+    sd->state.killer = 0;
+    sd->state.killable = 0;
 
     return 0;
 }
@@ -899,6 +926,7 @@ int pc_calcstatus(dumb_ptr<map_session_data> sd, int first)
     int bl;
     int aspd_rate, refinedef = 0;
     int str, dstr, dex;
+    int b_pvpon = 0, b_killer = 0, b_killable = 0;
 
     nullpo_retz(sd);
 
@@ -927,6 +955,10 @@ int pc_calcstatus(dumb_ptr<map_session_data> sd, int first)
     b_mdef = sd->mdef;
     b_mdef2 = sd->mdef2;
     b_base_atk = sd->base_atk;
+    b_pvpon = sd->state.pvpon;
+    if (!pc_isdead(sd))
+        b_killer = sd->state.killer;
+        b_killable = sd->state.killable;
 
     sd->max_weight = max_weight_base_0 + sd->status.attrs[ATTR::STR] * 300;
 
@@ -1399,6 +1431,13 @@ int pc_calcstatus(dumb_ptr<map_session_data> sd, int first)
         clif_updatestatus(sd, SP::HP);
     if (b_sp != sd->status.sp)
         clif_updatestatus(sd, SP::SP);
+    if (b_pvpon != sd->state.pvpon)
+        sd->state.pvpon = b_pvpon;
+    if (b_killer != sd->state.killer)
+        sd->state.killable = b_killer;
+    if (b_killable != sd->state.killable)
+        sd->state.killable = b_killable;
+
 
     return 0;
 }

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -290,7 +290,9 @@ int pc_iskiller(dumb_ptr<map_session_data> src,
 
     if (src->bl_type != BL::PC || target->bl_type != BL::PC)
         return 0;
-    if (src->state.pvpon && target->state.pvpon && !src->bl_m->flag.get(MapFlag::NOPVP))
+    if ((src->state.pvpchannel == 1) && (target->state.pvpchannel == 1) && !src->bl_m->flag.get(MapFlag::NOPVP))
+        return 1;
+    if ((src->state.pvpchannel > 1) && (target->state.pvpchannel == src->state.pvpchannel)) // this one does not respect NOPVP
         return 1;
     return 0;
 }
@@ -919,7 +921,7 @@ int pc_calcstatus(dumb_ptr<map_session_data> sd, int first)
     int bl;
     int aspd_rate, refinedef = 0;
     int str, dstr, dex;
-    int b_pvpon = 0;
+    int b_pvpchannel = 0;
 
     nullpo_retz(sd);
 
@@ -948,7 +950,7 @@ int pc_calcstatus(dumb_ptr<map_session_data> sd, int first)
     b_mdef = sd->mdef;
     b_mdef2 = sd->mdef2;
     b_base_atk = sd->base_atk;
-    b_pvpon = sd->state.pvpon;
+    b_pvpchannel = sd->state.pvpchannel;
 
     sd->max_weight = max_weight_base_0 + sd->status.attrs[ATTR::STR] * 300;
 
@@ -1421,8 +1423,8 @@ int pc_calcstatus(dumb_ptr<map_session_data> sd, int first)
         clif_updatestatus(sd, SP::HP);
     if (b_sp != sd->status.sp)
         clif_updatestatus(sd, SP::SP);
-    if (b_pvpon != sd->state.pvpon)
-        sd->state.pvpon = b_pvpon;
+    if (b_pvpchannel != sd->state.pvpchannel)
+        sd->state.pvpchannel = b_pvpchannel;
 
     return 0;
 }

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -294,7 +294,7 @@ int pc_iskiller(dumb_ptr<map_session_data> src,
         return 1;
     if (target->state.killable)
         return 1;
-    if (src->state.pvpon && target->state.pvpon)
+    if (src->state.pvpon && target->state.pvpon && !src->bl_m->flag.get(MapFlag::NOPVP))
         return 1;
     return 0;
 }

--- a/src/map/pc.hpp
+++ b/src/map/pc.hpp
@@ -170,6 +170,8 @@ void pc_setstand(dumb_ptr<map_session_data> sd);
 void pc_cleanup(dumb_ptr<map_session_data> sd);  // [Fate] Clean up after a logged-out PC
 
 int pc_read_gm_account(Session *, const std::vector<Packet_Repeat<0x2b15>>&);
+int pc_setpvptimer(dumb_ptr<map_session_data> sd, interval_t);
+int pc_delpvptimer(dumb_ptr<map_session_data> sd);
 int pc_setinvincibletimer(dumb_ptr<map_session_data> sd, interval_t);
 int pc_delinvincibletimer(dumb_ptr<map_session_data> sd);
 int pc_logout(dumb_ptr<map_session_data> sd);   // [fate] Player logs out

--- a/src/map/script-fun.cpp
+++ b/src/map/script-fun.cpp
@@ -2175,6 +2175,63 @@ void builtin_pvpoff(ScriptState *st)
     }
 }
 
+static
+void builtin_pvp(ScriptState *st)
+{
+    dumb_ptr<map_session_data> sd = script_rid2sd(st);
+    int flag;
+    flag = conv_num(st, &AARG(0));
+    if (flag > 1)
+        flag = 1;
+
+    sd->state.pvpon = flag;
+}
+
+static
+void builtin_getpvpflag(ScriptState *st)
+{
+    dumb_ptr<map_session_data> sd = script_rid2sd(st);
+    int num = conv_num(st, &AARG(0));
+
+    switch (num){
+        case 0:
+            num = sd->state.pvpon;
+            break;
+        case 1:
+            num = sd->state.killer;
+            break;
+        case 2:
+            num = sd->state.killable;
+            break;
+    }
+
+    push_int<ScriptDataInt>(st->stack, num);
+}
+
+static
+void builtin_killer(ScriptState *st)
+{
+    dumb_ptr<map_session_data> sd = script_rid2sd(st);
+    int flag;
+    flag = conv_num(st, &AARG(0));
+    if (flag > 1)
+        flag = 1;
+
+    sd->state.killer = flag;
+}
+
+static
+void builtin_killable(ScriptState *st)
+{
+    dumb_ptr<map_session_data> sd = script_rid2sd(st);
+    int flag;
+    flag = conv_num(st, &AARG(0));
+    if (flag > 1)
+        flag = 1;
+
+    sd->state.killable = flag;
+}
+
 /*==========================================
  *      NPCエモーション
  *------------------------------------------
@@ -3078,6 +3135,10 @@ BuiltinFunction builtin_functions[] =
     BUILTIN(getmapflag, "Mi"_s, 'i'),
     BUILTIN(pvpon, "M"_s, '\0'),
     BUILTIN(pvpoff, "M"_s, '\0'),
+    BUILTIN(pvp, "i"_s, '\0'),
+    BUILTIN(getpvpflag, "i"_s, 'i'),
+    BUILTIN(killer, "i"_s, '\0'),
+    BUILTIN(killable, "i"_s, '\0'),
     BUILTIN(emotion, "i"_s, '\0'),
     BUILTIN(mapwarp, "MMxy"_s, '\0'),
     BUILTIN(cmdothernpc, "ss"_s, '\0'),

--- a/src/map/script-fun.cpp
+++ b/src/map/script-fun.cpp
@@ -2192,20 +2192,24 @@ void builtin_getpvpflag(ScriptState *st)
 {
     dumb_ptr<map_session_data> sd = script_rid2sd(st);
     int num = conv_num(st, &AARG(0));
+    int flag = 0;
 
     switch (num){
         case 0:
-            num = sd->state.pvpon;
+            flag = sd->state.pvpon;
             break;
         case 1:
-            num = sd->state.killer;
+            flag = sd->state.killer;
             break;
         case 2:
-            num = sd->state.killable;
+            flag = sd->state.killable;
+            break;
+        case 3:
+            flag = bool(sd->status.option & Opt0::HIDE);
             break;
     }
 
-    push_int<ScriptDataInt>(st->stack, num);
+    push_int<ScriptDataInt>(st->stack, flag);
 }
 
 static

--- a/src/map/script-fun.cpp
+++ b/src/map/script-fun.cpp
@@ -2199,41 +2199,11 @@ void builtin_getpvpflag(ScriptState *st)
             flag = sd->state.pvpon;
             break;
         case 1:
-            flag = sd->state.killer;
-            break;
-        case 2:
-            flag = sd->state.killable;
-            break;
-        case 3:
             flag = bool(sd->status.option & Opt0::HIDE);
             break;
     }
 
     push_int<ScriptDataInt>(st->stack, flag);
-}
-
-static
-void builtin_killer(ScriptState *st)
-{
-    dumb_ptr<map_session_data> sd = script_rid2sd(st);
-    int flag;
-    flag = conv_num(st, &AARG(0));
-    if (flag > 1)
-        flag = 1;
-
-    sd->state.killer = flag;
-}
-
-static
-void builtin_killable(ScriptState *st)
-{
-    dumb_ptr<map_session_data> sd = script_rid2sd(st);
-    int flag;
-    flag = conv_num(st, &AARG(0));
-    if (flag > 1)
-        flag = 1;
-
-    sd->state.killable = flag;
 }
 
 /*==========================================
@@ -3141,8 +3111,6 @@ BuiltinFunction builtin_functions[] =
     BUILTIN(pvpoff, "M"_s, '\0'),
     BUILTIN(pvp, "i"_s, '\0'),
     BUILTIN(getpvpflag, "i"_s, 'i'),
-    BUILTIN(killer, "i"_s, '\0'),
-    BUILTIN(killable, "i"_s, '\0'),
     BUILTIN(emotion, "i"_s, '\0'),
     BUILTIN(mapwarp, "MMxy"_s, '\0'),
     BUILTIN(cmdothernpc, "ss"_s, '\0'),

--- a/src/map/script-fun.cpp
+++ b/src/map/script-fun.cpp
@@ -2176,15 +2176,15 @@ void builtin_pvpoff(ScriptState *st)
 }
 
 static
-void builtin_pvp(ScriptState *st)
+void builtin_setpvpchannel(ScriptState *st)
 {
     dumb_ptr<map_session_data> sd = script_rid2sd(st);
     int flag;
     flag = conv_num(st, &AARG(0));
-    if (flag > 1)
-        flag = 1;
+    if (flag < 1)
+        flag = 0;
 
-    sd->state.pvpon = flag;
+    sd->state.pvpchannel = flag;
 }
 
 static
@@ -2196,7 +2196,7 @@ void builtin_getpvpflag(ScriptState *st)
 
     switch (num){
         case 0:
-            flag = sd->state.pvpon;
+            flag = sd->state.pvpchannel;
             break;
         case 1:
             flag = bool(sd->status.option & Opt0::HIDE);
@@ -3109,7 +3109,7 @@ BuiltinFunction builtin_functions[] =
     BUILTIN(getmapflag, "Mi"_s, 'i'),
     BUILTIN(pvpon, "M"_s, '\0'),
     BUILTIN(pvpoff, "M"_s, '\0'),
-    BUILTIN(pvp, "i"_s, '\0'),
+    BUILTIN(setpvpchannel, "i"_s, '\0'),
     BUILTIN(getpvpflag, "i"_s, 'i'),
     BUILTIN(emotion, "i"_s, '\0'),
     BUILTIN(mapwarp, "MMxy"_s, '\0'),

--- a/tools/config.py
+++ b/tools/config.py
@@ -614,6 +614,7 @@ def build_config():
     battle_conf.opt('mob_count_rate', percent, '100')
     battle_conf.opt('basic_skill_check', bool, 'true')
     battle_conf.opt('player_invincible_time', milliseconds, '5_s')
+    battle_conf.opt('player_pvp_time', milliseconds, '5_s')
     battle_conf.opt('skill_min_damage', bool, 'false')
     battle_conf.opt('natural_healhp_interval', milliseconds, '6_s', {map_h}, min='NATURAL_HEAL_INTERVAL')
     battle_conf.opt('natural_healsp_interval', milliseconds, '8_s', {map_h}, min='NATURAL_HEAL_INTERVAL')


### PR DESCRIPTION
channel 0 = no channel
channel 1 = default channel (given by @pvp)
channel 2 to 2147483647 = special-purpose channels

I want to reserve channel 20 to 25 for Rouge if possible (I leave 2 to 19 unused in case we need to add more "default" channels in the future)
## Usage

@pvp to join the main channel
@pvp to leave (ONLY when in the main channel)
## Builtins

setpvpchannel <channel>; to set the channel
getpvpflag(0) to get the channel
