### PR TITLE
moar work on magic

### DIFF
--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -304,7 +304,6 @@ struct npc_timerevent_list
 {
     interval_t timer;
     int pos;
-    BlockId parent;
 };
 struct npc_label_list
 {
@@ -360,6 +359,9 @@ public:
         // Diameter.
         short xs, ys;
         bool event_needs_map;
+
+        // the npc containing the actual script
+        BlockId parent;
 
         // Whether the timer advances if not beyond end.
         bool timer_active;

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -290,8 +290,8 @@ void npc_event_doall_sub(NpcEvent key, struct event_data *ev,
 
     if (name == p)
     {
-        if (name == stringish<ScriptLabel>("OnInit"_s) && ev->nd->disposable)
-            return; // do not run OnInit for temporary npcs
+        if (ev->nd->disposable)
+            return; // temporary npcs only respond to commands directly issued to them
         run_script_l(ScriptPointer(script_or_parent(ev->nd), ev->pos), rid, ev->nd->bl_id,
                 argv);
         (*c)++;

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -61,6 +61,15 @@ namespace tmwa
 {
 namespace map
 {
+const std::vector<ByteCode> fake_buffer;
+const ScriptBuffer& fake_script = reinterpret_cast<const ScriptBuffer&>(fake_buffer);
+
+static
+Borrowed<const ScriptBuffer> script_or_parent(dumb_ptr<npc_data_script> nd)
+{
+    return borrow(nd->scr.parent ? fake_script : *nd->scr.script);
+}
+
 BlockId npc_get_new_npc_id(void)
 {
     BlockId rv = npc_id;
@@ -224,7 +233,7 @@ int magic_message(dumb_ptr<map_session_data> caster, XString source_invocation)
         if (spell_event.label)
             caster->npc_pos = npc_event_do_l(spell_event, caster->bl_id, arg);
         else
-            caster->npc_pos = run_script_l(ScriptPointer(borrow(*nd->is_script()->scr.script), 0), caster->bl_id, nd->bl_id, arg);
+            caster->npc_pos = run_script_l(ScriptPointer(script_or_parent(nd->is_script()), 0), caster->bl_id, nd->bl_id, arg);
         return 1;
     }
     return 0;
@@ -281,7 +290,9 @@ void npc_event_doall_sub(NpcEvent key, struct event_data *ev,
 
     if (name == p)
     {
-        run_script_l(ScriptPointer(borrow(*ev->nd->scr.script), ev->pos), rid, ev->nd->bl_id,
+        if (name == stringish<ScriptLabel>("OnInit"_s) && ev->nd->disposable)
+            return; // do not run OnInit for temporary npcs
+        run_script_l(ScriptPointer(script_or_parent(ev->nd), ev->pos), rid, ev->nd->bl_id,
                 argv);
         (*c)++;
     }
@@ -304,12 +315,7 @@ void npc_event_do_sub(NpcEvent key, struct event_data *ev,
 
     if (name == key)
     {
-        if (ev->child != BlockId())
-        {
-            rid = ev->child; // run as another npc
-        }
-
-        run_script_l(ScriptPointer(borrow(*ev->nd->scr.script), ev->pos), rid, ev->nd->bl_id,
+        run_script_l(ScriptPointer(script_or_parent(ev->nd), ev->pos), rid, ev->nd->bl_id,
                 argv);
         (*c)++;
     }
@@ -419,7 +425,7 @@ void npc_eventtimer(TimerData *, tick_t, BlockId id, NpcEvent data)
             return;
     }
 
-    run_script(ScriptPointer(borrow(*nd->scr.script), ev->pos), id, nd->bl_id);
+    run_script(ScriptPointer(script_or_parent(nd), ev->pos), id, nd->bl_id);
 }
 
 /*==========================================
@@ -491,14 +497,7 @@ void npc_timerevent(TimerData *, tick_t tick, BlockId id, interval_t data)
                     id, next));
     }
 
-    if (te->parent != BlockId())
-    {
-        nd = map_id2bl(te->parent)->is_npc()->is_script();
-    }
-    else
-        id = BlockId();
-
-    run_script(ScriptPointer(borrow(*nd->scr.script), te->pos), id, nd->bl_id);
+    run_script(ScriptPointer(script_or_parent(nd), te->pos), BlockId(), nd->bl_id);
 }
 
 /// Start (or resume) counting ticks to the next npc_timerevent.
@@ -663,7 +662,7 @@ int npc_event(dumb_ptr<map_session_data> sd, NpcEvent eventname,
 
     sd->npc_id = nd->bl_id;
     sd->npc_pos =
-        run_script(ScriptPointer(borrow(*nd->scr.script), ev->pos), sd->bl_id, nd->bl_id);
+        run_script(ScriptPointer(script_or_parent(nd), ev->pos), sd->bl_id, nd->bl_id);
     return 0;
 }
 
@@ -817,7 +816,7 @@ int npc_click(dumb_ptr<map_session_data> sd, BlockId id)
             npc_event_dequeue(sd);
             break;
         case NpcSubtype::SCRIPT:
-            sd->npc_pos = run_script(ScriptPointer(borrow(*nd->is_script()->scr.script), 0), sd->bl_id, id);
+            sd->npc_pos = run_script(ScriptPointer(script_or_parent(nd->is_script()), 0), sd->bl_id, id);
             break;
         case NpcSubtype::MESSAGE:
             if (nd->is_message()->message)
@@ -858,7 +857,7 @@ int npc_scriptcont(dumb_ptr<map_session_data> sd, BlockId id)
         return 0;
     }
 
-    sd->npc_pos = run_script(ScriptPointer(borrow(*nd->is_script()->scr.script), sd->npc_pos), sd->bl_id, id);
+    sd->npc_pos = run_script(ScriptPointer(script_or_parent(nd->is_script()), sd->npc_pos), sd->bl_id, id);
 
     return 0;
 }

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -1043,18 +1043,18 @@ void npc_free_internal(dumb_ptr<npc_data> nd_)
     if (nd_->npc_subtype == NpcSubtype::SCRIPT)
     {
         dumb_ptr<npc_data_script> nd = nd_->is_script();
+        nd->scr.timerid.cancel();
         nd->scr.timer_eventv.clear();
-
-        {
-            nd->scr.script.reset();
-            nd->scr.label_listv.clear();
-        }
+        nd->scr.script.reset();
+        nd->scr.label_listv.clear();
     }
     else if (nd_->npc_subtype == NpcSubtype::MESSAGE)
     {
         dumb_ptr<npc_data_message> nd = nd_->is_message();
         nd->message = AString();
     }
+    if (nd_->name)
+        npcs_by_name.put(nd_->name, nullptr);
     nd_.delete_();
 }
 

--- a/src/map/script-call-internal.hpp
+++ b/src/map/script-call-internal.hpp
@@ -25,6 +25,8 @@
 
 #include "../mmo/ids.hpp"
 
+#include "../strings/rstring.hpp"
+#include "../generic/db.hpp"
 #include "script-persist.hpp"
 
 
@@ -54,6 +56,13 @@ public:
     BlockId rid, oid;
     ScriptPointer scriptp, new_scriptp;
     int defsp, new_defsp, freeloop;
+
+    // register keys are ints (interned)
+    // Not anymore! Well, sort of.
+    DMap<SIR, int> regm;
+    // can't be DMap because we want predictable .c_str()s
+    // TODO this can change now
+    Map<SIR, RString> regstrm;
 };
 
 void run_func(ScriptState *st);
@@ -73,6 +82,7 @@ void get_val(dumb_ptr<block_list> sd, struct script_data *data);
 __attribute__((deprecated))
 void get_val(ScriptState *st, struct script_data *data);
 struct script_data get_val2(ScriptState *st, SIR reg);
+void set_scope_reg(ScriptState *, SIR, struct script_data);
 void set_reg(dumb_ptr<block_list> sd, VariableCode type, SIR reg, struct script_data vd);
 void set_reg(dumb_ptr<block_list> sd, VariableCode type, SIR reg, int id);
 void set_reg(dumb_ptr<block_list> sd, VariableCode type, SIR reg, RString zd);

--- a/src/map/script-call.cpp
+++ b/src/map/script-call.cpp
@@ -894,6 +894,24 @@ int run_script_l(ScriptPointer sp, BlockId rid, BlockId oid,
     ScriptState st;
     dumb_ptr<block_list> bl = map_id2bl(rid);
     dumb_ptr<map_session_data> sd = bl? bl->is_player(): nullptr;
+    if (oid)
+    {
+        dumb_ptr<block_list> oid_bl = map_id2bl(oid);
+        if (oid_bl->bl_type == BL::NPC)
+        {
+            dumb_ptr<npc_data> nd = oid_bl->is_npc();
+            if(nd->npc_subtype == NpcSubtype::SCRIPT)
+            {
+                dumb_ptr<npc_data_script> nds = nd->is_script();
+                if (nds->scr.parent)
+                {
+                    dumb_ptr<npc_data_script> parent = map_id2bl(nds->scr.parent)->is_npc()->is_script();
+                    assert(parent->bl_type == BL::NPC && parent->npc_subtype == NpcSubtype::SCRIPT);
+                    sp = ScriptPointer(borrow(*parent->scr.script), sp.pos);
+                }
+            }
+        }
+    }
     P<const ScriptBuffer> rootscript = TRY_UNWRAP(sp.code, return -1);
     int i;
     if (sp.pos >> 24)
@@ -909,9 +927,6 @@ int run_script_l(ScriptPointer sp, BlockId rid, BlockId oid,
     st.scriptp = sp;
     st.rid = rid;
     st.oid = oid;
-
-    if(!sd && rid)
-        st.oid = rid; // run script as another npc
 
     for (i = 0; i < args.size(); i++)
     {

--- a/src/map/script-fun.cpp
+++ b/src/map/script-fun.cpp
@@ -629,12 +629,8 @@ void builtin_destroy(ScriptState *st)
     dumb_ptr<npc_data_script> nd = map_id2bl(id)->is_npc()->is_script();
     if(!nd)
         return;
-
     assert(nd->disposable == true);
-    dumb_ptr<npc_data_script> nd_null;
-    npc_enable(nd->name, 0);
-    npcs_by_name.put(nd->name, nd_null);
-    npc_delete(nd);
+    npc_free(nd);
     if (!HARG(0))
         st->state = ScriptEndState::END;
 }

--- a/src/map/script-fun.cpp
+++ b/src/map/script-fun.cpp
@@ -1903,6 +1903,20 @@ void builtin_addtimer(ScriptState *st)
 }
 
 /*==========================================
+ * NPCイベントタイマー追加
+ *------------------------------------------
+ */
+static
+void builtin_addnpctimer(ScriptState *st)
+{
+    interval_t tick = static_cast<interval_t>(conv_num(st, &AARG(0)));
+    ZString event_ = ZString(conv_str(st, &AARG(1)));
+    NpcEvent event;
+    extract(event_, &event);
+    npc_addeventtimer(map_id2bl(st->oid), tick, event);
+}
+
+/*==========================================
  * NPCタイマー初期化
  *------------------------------------------
  */
@@ -3800,6 +3814,7 @@ BuiltinFunction builtin_functions[] =
     BUILTIN(killmonster, "ME"_s, '\0'),
     BUILTIN(donpcevent, "E"_s, '\0'),
     BUILTIN(addtimer, "tE"_s, '\0'),
+    BUILTIN(addnpctimer, "tE"_s, '\0'),
     BUILTIN(initnpctimer, "?"_s, '\0'),
     BUILTIN(startnpctimer, "?"_s, '\0'),
     BUILTIN(stopnpctimer, "?"_s, '\0'),

--- a/src/map/script-fun.cpp
+++ b/src/map/script-fun.cpp
@@ -3608,6 +3608,18 @@ void builtin_gety(ScriptState *st)
     push_int<ScriptDataInt>(st->stack, sd->bl_y);
 }
 
+/*============================
+ * Gets the PC's direction
+ *----------------------------
+ */
+static
+void builtin_getdir(ScriptState *st)
+{
+    dumb_ptr<map_session_data> sd = script_rid2sd(st);
+
+    push_int<ScriptDataInt>(st->stack, static_cast<uint8_t>(sd->dir));
+}
+
 /*
  * Get the PC's current map's name
  */
@@ -3861,6 +3873,7 @@ BuiltinFunction builtin_functions[] =
     BUILTIN(destroy, "?"_s, '\0'),
     BUILTIN(getx, ""_s, 'i'),
     BUILTIN(gety, ""_s, 'i'),
+    BUILTIN(getdir, ""_s, 'i'),
     BUILTIN(getnpcx, "?"_s, 'i'),
     BUILTIN(getnpcy, "?"_s, 'i'),
     BUILTIN(strnpcinfo, "i?"_s, 's'),

--- a/src/map/script-fun.cpp
+++ b/src/map/script-fun.cpp
@@ -3630,11 +3630,23 @@ void builtin_strnpcinfo(ScriptState *st)
     dumb_ptr<npc_data> nd;
 
     if(HARG(1)){
-        NpcName npc = stringish<NpcName>(ZString(conv_str(st, &AARG(1))));
-        nd = npc_name2id(npc);
+        struct script_data *sdata = &AARG(1);
+        get_val(st, sdata);
+
+        if (sdata->is<ScriptDataStr>())
+        {
+            NpcName name = stringish<NpcName>(ZString(conv_str(st, sdata)));
+            nd = npc_name2id(name);
+        }
+        else
+        {
+            BlockId id = wrap<BlockId>(conv_num(st, sdata));
+            nd = map_id2bl(id)->is_npc();
+        }
+
         if (!nd)
         {
-            PRINTF("builtin_strnpcinfo: no such npc: '%s'\n"_fmt, npc);
+            PRINTF("builtin_strnpcinfo: npc not found\n"_fmt);
             return;
         }
     } else {

--- a/src/map/script-parse.cpp
+++ b/src/map/script-parse.cpp
@@ -285,6 +285,8 @@ ZString::iterator skip_word(ZString::iterator p)
         p++;                    // 一時的変数用(like weiss)
     if (*p == '.')
         p++;                    // npc
+    if (*p == '@')
+        p++;                    // scope
     if (*p == '#')
         p++;                    // account変数用
     if (*p == '#')


### PR DESCRIPTION
This enables puppets to use ALL events that normal npcs can use (but I made puppets only respond to direct commands). For example, puppets can now have an `OnClick` event:

```
-|script|Magic Council|32767
{
    mes "The wizard seems to ignore you.";
    next;
    mes "Perhaps you should come back later.";
    close;

OnInit:
    set .void, puppet("001-2", 99,  22, "Wizard#1", 355);
    set .void, puppet("001-2", 92,  24, "Wizard#2", 356);
    set .void, puppet("001-2", 92,  30, "Wizard#3", 357);
    set .void, puppet("001-2", 99,  32, "Wizard#4", 358);
    set .void, puppet("001-2", 110, 22, "Wizard#5", 359);
    set .void, puppet("001-2", 117, 24, "Wizard#6", 360);
    set .void, puppet("001-2", 117, 30, "Wizard#7", 361);
    set .void, puppet("001-2", 110, 32, "Wizard#8", 362);
    end;
}
```

**Note:** we can not make temporary npcs have a `OnTouch` trigger (x,y) because it modifies map cells.
