### PR TITLE
Magic v3... again

### DIFF
--- a/src/map/globals.cpp
+++ b/src/map/globals.cpp
@@ -73,7 +73,6 @@ namespace tmwa
         BlockId npc_id = START_NPC_NUM;
         Map<NpcEvent, struct event_data> ev_db;
         DMap<NpcName, dumb_ptr<npc_data>> npcs_by_name;
-        DMap<RString, NpcName> spells_by_name;
         DMap<RString, NpcEvent> spells_by_events;
         // used for clock-based event triggers
         // only tm_min, tm_hour, and tm_mday are used

--- a/src/map/globals.hpp
+++ b/src/map/globals.hpp
@@ -68,7 +68,6 @@ namespace tmwa
         extern BlockId npc_id;
         extern Map<NpcEvent, event_data> ev_db;
         extern DMap<NpcName, dumb_ptr<npc_data>> npcs_by_name;
-        extern DMap<RString, NpcName> spells_by_name;
         extern DMap<RString, NpcEvent> spells_by_events;
         extern tm ev_tm_b;
         extern Map<PartyId, PartyMost> party_db;

--- a/src/map/npc.hpp
+++ b/src/map/npc.hpp
@@ -44,7 +44,18 @@ constexpr Species FAKE_NPC_CLASS = wrap<Species>(127);
 constexpr Species INVISIBLE_CLASS = wrap<Species>(32767);
 
 int npc_event_dequeue(dumb_ptr<map_session_data> sd);
-int npc_event(dumb_ptr<map_session_data> sd, NpcEvent npcname, int);
+int npc_event(dumb_ptr<map_session_data>, NpcEvent, int, Slice<argrec_t>);
+int npc_event(BlockId, NpcEvent, int, Slice<argrec_t>);
+inline
+int npc_event(dumb_ptr<map_session_data> sd, NpcEvent npcname, int i)
+{
+    return npc_event(sd, npcname, i, nullptr);
+}
+inline
+int npc_event(BlockId rid, NpcEvent eventname, int mob_kill, Slice<argrec_t> args)
+{
+    return npc_event(rid ? map_id2bl(rid)->is_player() : nullptr, eventname, mob_kill, args);
+}
 int npc_addeventtimer(dumb_ptr<block_list> bl, interval_t tick, NpcEvent name);
 int npc_touch_areanpc(dumb_ptr<map_session_data>, Borrowed<map_local>, int, int);
 int npc_click(dumb_ptr<map_session_data>, BlockId);
@@ -67,7 +78,11 @@ void npc_free(dumb_ptr<npc_data> npc);
 int npc_event_do_oninit(void);
 
 int npc_event_doall_l(ScriptLabel name, BlockId rid, Slice<argrec_t> argv);
-int npc_event_do_l(NpcEvent name, BlockId rid, Slice<argrec_t> argv);
+inline
+int npc_event_do_l(NpcEvent name, BlockId rid, Slice<argrec_t> argv)
+{
+    return npc_event(rid, name, 0, argv);
+}
 inline
 int npc_event_doall(ScriptLabel name)
 {

--- a/src/map/script-fun.cpp
+++ b/src/map/script-fun.cpp
@@ -3382,14 +3382,10 @@ static
 void builtin_registercmd(ScriptState *st)
 {
     RString evoke = conv_str(st, &AARG(0));
-    NpcName npcname = stringish<NpcName>(conv_str(st, &AARG(1)));
     ZString event_ = conv_str(st, &AARG(1));
     NpcEvent event;
     extract(event_, &event);
-    if (event.label)
-        spells_by_events.put(evoke, event);
-    else
-        spells_by_name.put(evoke, npcname);
+    spells_by_events.put(evoke, event);
 }
 
 /*==========================================


### PR DESCRIPTION
I removed the ugly workaround for `npc::event` vs. `npc` and extended it to npc_event instead of just magic so it can be used with any event. This means that you can do things like `addtimer 0, "npc name";` and it will work
